### PR TITLE
날시앱 [STEP1] 미뇽

### DIFF
--- a/WeatherForecast/WeatherForecast.xcodeproj/project.pbxproj
+++ b/WeatherForecast/WeatherForecast.xcodeproj/project.pbxproj
@@ -8,7 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		7D6443382BA7ACF5004340DB /* DetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D6443372BA7ACF5004340DB /* DetailView.swift */; };
-		7D64433A2BA903AA004340DB /* TableViewDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D6443392BA903AA004340DB /* TableViewDataSource.swift */; };
+		7D64433A2BA903AA004340DB /* WeatherListDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D6443392BA903AA004340DB /* WeatherListDataSource.swift */; };
 		7D64433C2BA90B5C004340DB /* Date+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D64433B2BA90B5C004340DB /* Date+.swift */; };
 		8E65653A2BA8891100A4634E /* ImageChacher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E6565392BA8891100A4634E /* ImageChacher.swift */; };
 		C741F6702B58F00500A4DDC0 /* Weather.swift in Sources */ = {isa = PBXBuildFile; fileRef = C741F66F2B58F00500A4DDC0 /* Weather.swift */; };
@@ -24,7 +24,7 @@
 
 /* Begin PBXFileReference section */
 		7D6443372BA7ACF5004340DB /* DetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailView.swift; sourceTree = "<group>"; };
-		7D6443392BA903AA004340DB /* TableViewDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TableViewDataSource.swift; sourceTree = "<group>"; };
+		7D6443392BA903AA004340DB /* WeatherListDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherListDataSource.swift; sourceTree = "<group>"; };
 		7D64433B2BA90B5C004340DB /* Date+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+.swift"; sourceTree = "<group>"; };
 		8E6565392BA8891100A4634E /* ImageChacher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageChacher.swift; sourceTree = "<group>"; };
 		C741F66F2B58F00500A4DDC0 /* Weather.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Weather.swift; sourceTree = "<group>"; };
@@ -82,7 +82,7 @@
 				C7743D9A2B21C38200DF0D09 /* Info.plist */,
 				7D6443372BA7ACF5004340DB /* DetailView.swift */,
 				8E6565392BA8891100A4634E /* ImageChacher.swift */,
-				7D6443392BA903AA004340DB /* TableViewDataSource.swift */,
+				7D6443392BA903AA004340DB /* WeatherListDataSource.swift */,
 				7D64433B2BA90B5C004340DB /* Date+.swift */,
 			);
 			path = WeatherForecast;
@@ -164,7 +164,7 @@
 				C7743D8D2B21C38100DF0D09 /* AppDelegate.swift in Sources */,
 				7D6443382BA7ACF5004340DB /* DetailView.swift in Sources */,
 				C7743DA32B21CA8600DF0D09 /* WeatherDetailViewController.swift in Sources */,
-				7D64433A2BA903AA004340DB /* TableViewDataSource.swift in Sources */,
+				7D64433A2BA903AA004340DB /* WeatherListDataSource.swift in Sources */,
 				8E65653A2BA8891100A4634E /* ImageChacher.swift in Sources */,
 				7D64433C2BA90B5C004340DB /* Date+.swift in Sources */,
 				C741F6702B58F00500A4DDC0 /* Weather.swift in Sources */,

--- a/WeatherForecast/WeatherForecast.xcodeproj/project.pbxproj
+++ b/WeatherForecast/WeatherForecast.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		7D6443382BA7ACF5004340DB /* DetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D6443372BA7ACF5004340DB /* DetailView.swift */; };
+		8E65653A2BA8891100A4634E /* ImageChacher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E6565392BA8891100A4634E /* ImageChacher.swift */; };
 		C741F6702B58F00500A4DDC0 /* Weather.swift in Sources */ = {isa = PBXBuildFile; fileRef = C741F66F2B58F00500A4DDC0 /* Weather.swift */; };
 		C7743D8D2B21C38100DF0D09 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7743D8C2B21C38100DF0D09 /* AppDelegate.swift */; };
 		C7743D8F2B21C38100DF0D09 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7743D8E2B21C38100DF0D09 /* SceneDelegate.swift */; };
@@ -21,6 +22,7 @@
 
 /* Begin PBXFileReference section */
 		7D6443372BA7ACF5004340DB /* DetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailView.swift; sourceTree = "<group>"; };
+		8E6565392BA8891100A4634E /* ImageChacher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageChacher.swift; sourceTree = "<group>"; };
 		C741F66F2B58F00500A4DDC0 /* Weather.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Weather.swift; sourceTree = "<group>"; };
 		C7743D892B21C38100DF0D09 /* WeatherForecast.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = WeatherForecast.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C7743D8C2B21C38100DF0D09 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -75,6 +77,7 @@
 				C7743D972B21C38200DF0D09 /* LaunchScreen.storyboard */,
 				C7743D9A2B21C38200DF0D09 /* Info.plist */,
 				7D6443372BA7ACF5004340DB /* DetailView.swift */,
+				8E6565392BA8891100A4634E /* ImageChacher.swift */,
 			);
 			path = WeatherForecast;
 			sourceTree = "<group>";
@@ -155,6 +158,7 @@
 				C7743D8D2B21C38100DF0D09 /* AppDelegate.swift in Sources */,
 				7D6443382BA7ACF5004340DB /* DetailView.swift in Sources */,
 				C7743DA32B21CA8600DF0D09 /* WeatherDetailViewController.swift in Sources */,
+				8E65653A2BA8891100A4634E /* ImageChacher.swift in Sources */,
 				C741F6702B58F00500A4DDC0 /* Weather.swift in Sources */,
 				C7743D8F2B21C38100DF0D09 /* SceneDelegate.swift in Sources */,
 			);

--- a/WeatherForecast/WeatherForecast.xcodeproj/project.pbxproj
+++ b/WeatherForecast/WeatherForecast.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		7D6443382BA7ACF5004340DB /* DetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D6443372BA7ACF5004340DB /* DetailView.swift */; };
 		C741F6702B58F00500A4DDC0 /* Weather.swift in Sources */ = {isa = PBXBuildFile; fileRef = C741F66F2B58F00500A4DDC0 /* Weather.swift */; };
 		C7743D8D2B21C38100DF0D09 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7743D8C2B21C38100DF0D09 /* AppDelegate.swift */; };
 		C7743D8F2B21C38100DF0D09 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7743D8E2B21C38100DF0D09 /* SceneDelegate.swift */; };
@@ -19,6 +20,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		7D6443372BA7ACF5004340DB /* DetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailView.swift; sourceTree = "<group>"; };
 		C741F66F2B58F00500A4DDC0 /* Weather.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Weather.swift; sourceTree = "<group>"; };
 		C7743D892B21C38100DF0D09 /* WeatherForecast.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = WeatherForecast.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C7743D8C2B21C38100DF0D09 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -72,6 +74,7 @@
 				C7743D952B21C38200DF0D09 /* Assets.xcassets */,
 				C7743D972B21C38200DF0D09 /* LaunchScreen.storyboard */,
 				C7743D9A2B21C38200DF0D09 /* Info.plist */,
+				7D6443372BA7ACF5004340DB /* DetailView.swift */,
 			);
 			path = WeatherForecast;
 			sourceTree = "<group>";
@@ -150,6 +153,7 @@
 				C7743DA12B21C3B400DF0D09 /* WeatherTableViewCell.swift in Sources */,
 				C7743D912B21C38100DF0D09 /* ViewController.swift in Sources */,
 				C7743D8D2B21C38100DF0D09 /* AppDelegate.swift in Sources */,
+				7D6443382BA7ACF5004340DB /* DetailView.swift in Sources */,
 				C7743DA32B21CA8600DF0D09 /* WeatherDetailViewController.swift in Sources */,
 				C741F6702B58F00500A4DDC0 /* Weather.swift in Sources */,
 				C7743D8F2B21C38100DF0D09 /* SceneDelegate.swift in Sources */,
@@ -304,6 +308,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = B36234Y8A9;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = WeatherForecast/Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -331,6 +336,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = B36234Y8A9;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = WeatherForecast/Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;

--- a/WeatherForecast/WeatherForecast.xcodeproj/project.pbxproj
+++ b/WeatherForecast/WeatherForecast.xcodeproj/project.pbxproj
@@ -8,11 +8,13 @@
 
 /* Begin PBXBuildFile section */
 		7D6443382BA7ACF5004340DB /* DetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D6443372BA7ACF5004340DB /* DetailView.swift */; };
+		7D64433A2BA903AA004340DB /* TableViewDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D6443392BA903AA004340DB /* TableViewDataSource.swift */; };
+		7D64433C2BA90B5C004340DB /* Date+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D64433B2BA90B5C004340DB /* Date+.swift */; };
 		8E65653A2BA8891100A4634E /* ImageChacher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E6565392BA8891100A4634E /* ImageChacher.swift */; };
 		C741F6702B58F00500A4DDC0 /* Weather.swift in Sources */ = {isa = PBXBuildFile; fileRef = C741F66F2B58F00500A4DDC0 /* Weather.swift */; };
 		C7743D8D2B21C38100DF0D09 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7743D8C2B21C38100DF0D09 /* AppDelegate.swift */; };
 		C7743D8F2B21C38100DF0D09 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7743D8E2B21C38100DF0D09 /* SceneDelegate.swift */; };
-		C7743D912B21C38100DF0D09 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7743D902B21C38100DF0D09 /* ViewController.swift */; };
+		C7743D912B21C38100DF0D09 /* WeatherListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7743D902B21C38100DF0D09 /* WeatherListViewController.swift */; };
 		C7743D942B21C38100DF0D09 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C7743D922B21C38100DF0D09 /* Main.storyboard */; };
 		C7743D962B21C38200DF0D09 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C7743D952B21C38200DF0D09 /* Assets.xcassets */; };
 		C7743D992B21C38200DF0D09 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C7743D972B21C38200DF0D09 /* LaunchScreen.storyboard */; };
@@ -22,12 +24,14 @@
 
 /* Begin PBXFileReference section */
 		7D6443372BA7ACF5004340DB /* DetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailView.swift; sourceTree = "<group>"; };
+		7D6443392BA903AA004340DB /* TableViewDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TableViewDataSource.swift; sourceTree = "<group>"; };
+		7D64433B2BA90B5C004340DB /* Date+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+.swift"; sourceTree = "<group>"; };
 		8E6565392BA8891100A4634E /* ImageChacher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageChacher.swift; sourceTree = "<group>"; };
 		C741F66F2B58F00500A4DDC0 /* Weather.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Weather.swift; sourceTree = "<group>"; };
 		C7743D892B21C38100DF0D09 /* WeatherForecast.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = WeatherForecast.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C7743D8C2B21C38100DF0D09 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C7743D8E2B21C38100DF0D09 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
-		C7743D902B21C38100DF0D09 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
+		C7743D902B21C38100DF0D09 /* WeatherListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherListViewController.swift; sourceTree = "<group>"; };
 		C7743D932B21C38100DF0D09 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		C7743D952B21C38200DF0D09 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		C7743D982B21C38200DF0D09 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
@@ -69,7 +73,7 @@
 				C7743D8C2B21C38100DF0D09 /* AppDelegate.swift */,
 				C7743D8E2B21C38100DF0D09 /* SceneDelegate.swift */,
 				C7743DA02B21C3B400DF0D09 /* WeatherTableViewCell.swift */,
-				C7743D902B21C38100DF0D09 /* ViewController.swift */,
+				C7743D902B21C38100DF0D09 /* WeatherListViewController.swift */,
 				C741F66F2B58F00500A4DDC0 /* Weather.swift */,
 				C7743DA22B21CA8500DF0D09 /* WeatherDetailViewController.swift */,
 				C7743D922B21C38100DF0D09 /* Main.storyboard */,
@@ -78,6 +82,8 @@
 				C7743D9A2B21C38200DF0D09 /* Info.plist */,
 				7D6443372BA7ACF5004340DB /* DetailView.swift */,
 				8E6565392BA8891100A4634E /* ImageChacher.swift */,
+				7D6443392BA903AA004340DB /* TableViewDataSource.swift */,
+				7D64433B2BA90B5C004340DB /* Date+.swift */,
 			);
 			path = WeatherForecast;
 			sourceTree = "<group>";
@@ -154,11 +160,13 @@
 			buildActionMask = 2147483647;
 			files = (
 				C7743DA12B21C3B400DF0D09 /* WeatherTableViewCell.swift in Sources */,
-				C7743D912B21C38100DF0D09 /* ViewController.swift in Sources */,
+				C7743D912B21C38100DF0D09 /* WeatherListViewController.swift in Sources */,
 				C7743D8D2B21C38100DF0D09 /* AppDelegate.swift in Sources */,
 				7D6443382BA7ACF5004340DB /* DetailView.swift in Sources */,
 				C7743DA32B21CA8600DF0D09 /* WeatherDetailViewController.swift in Sources */,
+				7D64433A2BA903AA004340DB /* TableViewDataSource.swift in Sources */,
 				8E65653A2BA8891100A4634E /* ImageChacher.swift in Sources */,
+				7D64433C2BA90B5C004340DB /* Date+.swift in Sources */,
 				C741F6702B58F00500A4DDC0 /* Weather.swift in Sources */,
 				C7743D8F2B21C38100DF0D09 /* SceneDelegate.swift in Sources */,
 			);

--- a/WeatherForecast/WeatherForecast.xcodeproj/project.pbxproj
+++ b/WeatherForecast/WeatherForecast.xcodeproj/project.pbxproj
@@ -8,8 +8,9 @@
 
 /* Begin PBXBuildFile section */
 		7D6443382BA7ACF5004340DB /* DetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D6443372BA7ACF5004340DB /* DetailView.swift */; };
-		7D64433A2BA903AA004340DB /* WeatherListDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D6443392BA903AA004340DB /* WeatherListDataSource.swift */; };
+		7D64433A2BA903AA004340DB /* WeatherListTableDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D6443392BA903AA004340DB /* WeatherListTableDataSource.swift */; };
 		7D64433C2BA90B5C004340DB /* Date+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D64433B2BA90B5C004340DB /* Date+.swift */; };
+		7D64433E2BA94CFC004340DB /* WeatherListTableDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D64433D2BA94CFC004340DB /* WeatherListTableDelegate.swift */; };
 		8E65653A2BA8891100A4634E /* ImageChacher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E6565392BA8891100A4634E /* ImageChacher.swift */; };
 		C741F6702B58F00500A4DDC0 /* Weather.swift in Sources */ = {isa = PBXBuildFile; fileRef = C741F66F2B58F00500A4DDC0 /* Weather.swift */; };
 		C7743D8D2B21C38100DF0D09 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7743D8C2B21C38100DF0D09 /* AppDelegate.swift */; };
@@ -24,8 +25,9 @@
 
 /* Begin PBXFileReference section */
 		7D6443372BA7ACF5004340DB /* DetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailView.swift; sourceTree = "<group>"; };
-		7D6443392BA903AA004340DB /* WeatherListDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherListDataSource.swift; sourceTree = "<group>"; };
+		7D6443392BA903AA004340DB /* WeatherListTableDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherListTableDataSource.swift; sourceTree = "<group>"; };
 		7D64433B2BA90B5C004340DB /* Date+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+.swift"; sourceTree = "<group>"; };
+		7D64433D2BA94CFC004340DB /* WeatherListTableDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherListTableDelegate.swift; sourceTree = "<group>"; };
 		8E6565392BA8891100A4634E /* ImageChacher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageChacher.swift; sourceTree = "<group>"; };
 		C741F66F2B58F00500A4DDC0 /* Weather.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Weather.swift; sourceTree = "<group>"; };
 		C7743D892B21C38100DF0D09 /* WeatherForecast.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = WeatherForecast.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -82,8 +84,9 @@
 				C7743D9A2B21C38200DF0D09 /* Info.plist */,
 				7D6443372BA7ACF5004340DB /* DetailView.swift */,
 				8E6565392BA8891100A4634E /* ImageChacher.swift */,
-				7D6443392BA903AA004340DB /* WeatherListDataSource.swift */,
+				7D6443392BA903AA004340DB /* WeatherListTableDataSource.swift */,
 				7D64433B2BA90B5C004340DB /* Date+.swift */,
+				7D64433D2BA94CFC004340DB /* WeatherListTableDelegate.swift */,
 			);
 			path = WeatherForecast;
 			sourceTree = "<group>";
@@ -163,8 +166,9 @@
 				C7743D912B21C38100DF0D09 /* WeatherListViewController.swift in Sources */,
 				C7743D8D2B21C38100DF0D09 /* AppDelegate.swift in Sources */,
 				7D6443382BA7ACF5004340DB /* DetailView.swift in Sources */,
+				7D64433E2BA94CFC004340DB /* WeatherListTableDelegate.swift in Sources */,
 				C7743DA32B21CA8600DF0D09 /* WeatherDetailViewController.swift in Sources */,
-				7D64433A2BA903AA004340DB /* WeatherListDataSource.swift in Sources */,
+				7D64433A2BA903AA004340DB /* WeatherListTableDataSource.swift in Sources */,
 				8E65653A2BA8891100A4634E /* ImageChacher.swift in Sources */,
 				7D64433C2BA90B5C004340DB /* Date+.swift in Sources */,
 				C741F6702B58F00500A4DDC0 /* Weather.swift in Sources */,

--- a/WeatherForecast/WeatherForecast/Base.lproj/Main.storyboard
+++ b/WeatherForecast/WeatherForecast/Base.lproj/Main.storyboard
@@ -1,17 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22155" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="wYg-u6-9nF">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="wYg-u6-9nF">
     <device id="retina6_12" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22131"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22504"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
-        <!--View Controller-->
+        <!--Weather List View Controller-->
         <scene sceneID="tne-QT-ifu">
             <objects>
-                <viewController id="BYZ-38-t0r" customClass="ViewController" customModule="WeatherForecast" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="BYZ-38-t0r" customClass="WeatherListViewController" customModule="WeatherForecast" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
                         <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>

--- a/WeatherForecast/WeatherForecast/Date+.swift
+++ b/WeatherForecast/WeatherForecast/Date+.swift
@@ -1,0 +1,33 @@
+//
+//  Date+.swift
+//  WeatherForecast
+//
+//  Created by 구 민영 on 3/19/24.
+//
+
+import Foundation
+
+extension Date {
+    private static var formatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "ko_KR")
+        formatter.timeZone = TimeZone(abbreviation: "KST")
+        return formatter
+    }()
+    
+    private static func fetchFormatter(_ format: String?) -> DateFormatter {
+        let formatter = Date.formatter
+        formatter.dateFormat = format
+        return formatter
+    }
+    
+    public static func string(from date: Foundation.Date, format: String = "") -> String? {
+        fetchFormatter(format).string(from: date)
+    }
+    
+    public static func string(from date: Foundation.Date, style: DateFormatter.Style) -> String {
+        let formatter = fetchFormatter(.none)
+        formatter.timeStyle = style
+        return formatter.string(from: date)
+    }
+}

--- a/WeatherForecast/WeatherForecast/DetailView.swift
+++ b/WeatherForecast/WeatherForecast/DetailView.swift
@@ -135,16 +135,10 @@ class DetailView: UIView {
     }
     
     func loadImage(to imageView: UIImageView) {
-        Task {
-            let iconName: String = infoProtocol.weatherForecastInfo.weather.icon
-            let urlString: String = "https://openweathermap.org/img/wn/\(iconName)@2x.png"
-            
-            guard let url: URL = URL(string: urlString),
-                  let (data, _) = try? await URLSession.shared.data(from: url),
-                  let image: UIImage = UIImage(data: data) else {
-                return
-            }
-            
+        let iconName: String = infoProtocol.weatherForecastInfo.weather.icon
+        let urlString: String = "https://openweathermap.org/img/wn/\(iconName)@2x.png"
+        
+        ImageChacher.shared.load(urlString: urlString) { image in
             imageView.image = image
         }
     }

--- a/WeatherForecast/WeatherForecast/DetailView.swift
+++ b/WeatherForecast/WeatherForecast/DetailView.swift
@@ -7,16 +7,29 @@
 
 import UIKit
 
-class DetailView: UIView {
-    let weatherForecastInfo: WeatherForecastInfo
-    let cityInfo: City
+protocol DetailViewInfoProtocol {
+    var weatherForecastInfo: WeatherForecastInfo { get set }
+    var cityInfo: City { get set }
+    var tempUnit: TempUnit { get set }
+}
+
+class DetailInfo: DetailViewInfoProtocol {
+    var weatherForecastInfo: WeatherForecastInfo
+    var cityInfo: City
     var tempUnit: TempUnit
     
     init(weatherForecastInfo: WeatherForecastInfo, cityInfo: City, tempUnit: TempUnit) {
         self.weatherForecastInfo = weatherForecastInfo
         self.cityInfo = cityInfo
         self.tempUnit = tempUnit
-        
+    }
+}
+
+class DetailView: UIView {
+    private let infoProtocol: DetailViewInfoProtocol
+    
+    init(weatherForecastInfo: WeatherForecastInfo, cityInfo: City, tempUnit: TempUnit) {
+        self.infoProtocol = DetailInfo(weatherForecastInfo: weatherForecastInfo, cityInfo: cityInfo, tempUnit: tempUnit)
         super.init(frame: .zero)
         layViews()
     }
@@ -78,21 +91,21 @@ class DetailView: UIView {
         func layLabels() {
             weatherGroupLabel.font = .preferredFont(forTextStyle: .largeTitle)
             weatherDescriptionLabel.font = .preferredFont(forTextStyle: .largeTitle)
-            weatherGroupLabel.text = weatherForecastInfo.weather.main
-            weatherDescriptionLabel.text = weatherForecastInfo.weather.description
-            temperatureLabel.text = "현재 기온 : \(weatherForecastInfo.main.temp)\(tempUnit.expression)"
-            feelsLikeLabel.text = "체감 기온 : \(weatherForecastInfo.main.feelsLike)\(tempUnit.expression)"
-            maximumTemperatureLable.text = "최고 기온 : \(weatherForecastInfo.main.tempMax)\(tempUnit.expression)"
-            minimumTemperatureLable.text = "최저 기온 : \(weatherForecastInfo.main.tempMin)\(tempUnit.expression)"
-            popLabel.text = "강수 확률 : \(weatherForecastInfo.main.pop * 100)%"
-            humidityLabel.text = "습도 : \(weatherForecastInfo.main.humidity)%"
+            weatherGroupLabel.text = infoProtocol.weatherForecastInfo.weather.main
+            weatherDescriptionLabel.text = infoProtocol.weatherForecastInfo.weather.description
+            temperatureLabel.text = "현재 기온 : \(infoProtocol.weatherForecastInfo.main.temp)\(infoProtocol.tempUnit.expression)"
+            feelsLikeLabel.text = "체감 기온 : \(infoProtocol.weatherForecastInfo.main.feelsLike)\(infoProtocol.tempUnit.expression)"
+            maximumTemperatureLable.text = "최고 기온 : \(infoProtocol.weatherForecastInfo.main.tempMax)\(infoProtocol.tempUnit.expression)"
+            minimumTemperatureLable.text = "최저 기온 : \(infoProtocol.weatherForecastInfo.main.tempMin)\(infoProtocol.tempUnit.expression)"
+            popLabel.text = "강수 확률 : \(infoProtocol.weatherForecastInfo.main.pop * 100)%"
+            humidityLabel.text = "습도 : \(infoProtocol.weatherForecastInfo.main.humidity)%"
             
             let formatter: DateFormatter = DateFormatter()
             formatter.dateFormat = .none
             formatter.timeStyle = .short
             formatter.locale = .init(identifier: "ko_KR")
-            sunriseTimeLabel.text = "일출 : \(formatter.string(from: Date(timeIntervalSince1970: cityInfo.sunrise)))"
-            sunsetTimeLabel.text = "일몰 : \(formatter.string(from: Date(timeIntervalSince1970: cityInfo.sunset)))"
+            sunriseTimeLabel.text = "일출 : \(formatter.string(from: Date(timeIntervalSince1970: infoProtocol.cityInfo.sunrise)))"
+            sunsetTimeLabel.text = "일몰 : \(formatter.string(from: Date(timeIntervalSince1970: infoProtocol.cityInfo.sunset)))"
         }
         
         func layMainStackView() {
@@ -123,7 +136,7 @@ class DetailView: UIView {
     
     func loadImage(to imageView: UIImageView) {
         Task {
-            let iconName: String = weatherForecastInfo.weather.icon
+            let iconName: String = infoProtocol.weatherForecastInfo.weather.icon
             let urlString: String = "https://openweathermap.org/img/wn/\(iconName)@2x.png"
             
             guard let url: URL = URL(string: urlString),

--- a/WeatherForecast/WeatherForecast/DetailView.swift
+++ b/WeatherForecast/WeatherForecast/DetailView.swift
@@ -1,0 +1,138 @@
+//
+//  DetailView.swift
+//  WeatherForecast
+//
+//  Created by 구 민영 on 3/18/24.
+//
+
+import UIKit
+
+class DetailView: UIView {
+    let weatherForecastInfo: WeatherForecastInfo
+    let cityInfo: City
+    var tempUnit: TempUnit
+    
+    init(weatherForecastInfo: WeatherForecastInfo, cityInfo: City, tempUnit: TempUnit) {
+        self.weatherForecastInfo = weatherForecastInfo
+        self.cityInfo = cityInfo
+        self.tempUnit = tempUnit
+        
+        super.init(frame: .zero)
+        layViews()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func layViews() {
+        let iconImageView: UIImageView = UIImageView()
+        let weatherGroupLabel: UILabel = UILabel()
+        let weatherDescriptionLabel: UILabel = UILabel()
+        let temperatureLabel: UILabel = UILabel()
+        let feelsLikeLabel: UILabel = UILabel()
+        let maximumTemperatureLable: UILabel = UILabel()
+        let minimumTemperatureLable: UILabel = UILabel()
+        let popLabel: UILabel = UILabel()
+        let humidityLabel: UILabel = UILabel()
+        let sunriseTimeLabel: UILabel = UILabel()
+        let sunsetTimeLabel: UILabel = UILabel()
+        let spacingView: UIView = UIView()
+        spacingView.backgroundColor = .clear
+        spacingView.setContentHuggingPriority(.defaultLow, for: .vertical)
+        
+        func mainStackView() -> UIStackView {
+            let mainStackView: UIStackView = .init(arrangedSubviews: [
+                iconImageView,
+                weatherGroupLabel,
+                weatherDescriptionLabel,
+                temperatureLabel,
+                feelsLikeLabel,
+                maximumTemperatureLable,
+                minimumTemperatureLable,
+                popLabel,
+                humidityLabel,
+                sunriseTimeLabel,
+                sunsetTimeLabel,
+                spacingView
+            ])
+                    
+            mainStackView.arrangedSubviews.forEach { subview in
+                guard let subview: UILabel = subview as? UILabel else { return }
+                subview.textColor = .black
+                subview.backgroundColor = .clear
+                subview.numberOfLines = 1
+                subview.textAlignment = .center
+                subview.font = .preferredFont(forTextStyle: .body)
+            }
+            
+            mainStackView.axis = .vertical
+            mainStackView.alignment = .center
+            mainStackView.spacing = 8
+            
+            mainStackView.translatesAutoresizingMaskIntoConstraints = false
+            
+            return mainStackView
+        }
+        
+        func layLabels() {
+            weatherGroupLabel.font = .preferredFont(forTextStyle: .largeTitle)
+            weatherDescriptionLabel.font = .preferredFont(forTextStyle: .largeTitle)
+            weatherGroupLabel.text = weatherForecastInfo.weather.main
+            weatherDescriptionLabel.text = weatherForecastInfo.weather.description
+            temperatureLabel.text = "현재 기온 : \(weatherForecastInfo.main.temp)\(tempUnit.expression)"
+            feelsLikeLabel.text = "체감 기온 : \(weatherForecastInfo.main.feelsLike)\(tempUnit.expression)"
+            maximumTemperatureLable.text = "최고 기온 : \(weatherForecastInfo.main.tempMax)\(tempUnit.expression)"
+            minimumTemperatureLable.text = "최저 기온 : \(weatherForecastInfo.main.tempMin)\(tempUnit.expression)"
+            popLabel.text = "강수 확률 : \(weatherForecastInfo.main.pop * 100)%"
+            humidityLabel.text = "습도 : \(weatherForecastInfo.main.humidity)%"
+            
+            let formatter: DateFormatter = DateFormatter()
+            formatter.dateFormat = .none
+            formatter.timeStyle = .short
+            formatter.locale = .init(identifier: "ko_KR")
+            sunriseTimeLabel.text = "일출 : \(formatter.string(from: Date(timeIntervalSince1970: cityInfo.sunrise)))"
+            sunsetTimeLabel.text = "일몰 : \(formatter.string(from: Date(timeIntervalSince1970: cityInfo.sunset)))"
+        }
+        
+        func layMainStackView() {
+            let mainStackView = mainStackView()
+            addSubview(mainStackView)
+            
+            
+            let safeArea: UILayoutGuide = self.safeAreaLayoutGuide
+            NSLayoutConstraint.activate([
+                mainStackView.topAnchor.constraint(equalTo: safeArea.topAnchor),
+                mainStackView.bottomAnchor.constraint(equalTo: safeArea.bottomAnchor),
+                mainStackView.leadingAnchor.constraint(equalTo: safeArea.leadingAnchor,
+                                                       constant: 16),
+                mainStackView.trailingAnchor.constraint(equalTo: safeArea.trailingAnchor,
+                                                       constant: -16),
+                iconImageView.widthAnchor.constraint(equalTo: iconImageView.heightAnchor),
+                iconImageView.widthAnchor.constraint(equalTo: safeArea.widthAnchor,
+                                                     multiplier: 0.3)
+            ])
+        }
+        
+
+        
+        layLabels()
+        layMainStackView()
+        loadImage(to: iconImageView)
+    }
+    
+    func loadImage(to imageView: UIImageView) {
+        Task {
+            let iconName: String = weatherForecastInfo.weather.icon
+            let urlString: String = "https://openweathermap.org/img/wn/\(iconName)@2x.png"
+            
+            guard let url: URL = URL(string: urlString),
+                  let (data, _) = try? await URLSession.shared.data(from: url),
+                  let image: UIImage = UIImage(data: data) else {
+                return
+            }
+            
+            imageView.image = image
+        }
+    }
+}

--- a/WeatherForecast/WeatherForecast/DetailView.swift
+++ b/WeatherForecast/WeatherForecast/DetailView.swift
@@ -13,7 +13,7 @@ protocol DetailViewInfoProtocol {
     var tempUnit: TempUnit { get set }
 }
 
-class DetailInfo: DetailViewInfoProtocol {
+struct DetailInfo: DetailViewInfoProtocol {
     var weatherForecastInfo: WeatherForecastInfo
     var cityInfo: City
     var tempUnit: TempUnit
@@ -26,10 +26,10 @@ class DetailInfo: DetailViewInfoProtocol {
 }
 
 class DetailView: UIView {
-    private let infoProtocol: DetailViewInfoProtocol
+    private let info: DetailViewInfoProtocol
     
     init(weatherForecastInfo: WeatherForecastInfo, cityInfo: City, tempUnit: TempUnit) {
-        self.infoProtocol = DetailInfo(weatherForecastInfo: weatherForecastInfo, cityInfo: cityInfo, tempUnit: tempUnit)
+        self.info = DetailInfo(weatherForecastInfo: weatherForecastInfo, cityInfo: cityInfo, tempUnit: tempUnit)
         super.init(frame: .zero)
         layViews()
     }
@@ -91,21 +91,16 @@ class DetailView: UIView {
         func layLabels() {
             weatherGroupLabel.font = .preferredFont(forTextStyle: .largeTitle)
             weatherDescriptionLabel.font = .preferredFont(forTextStyle: .largeTitle)
-            weatherGroupLabel.text = infoProtocol.weatherForecastInfo.weather.main
-            weatherDescriptionLabel.text = infoProtocol.weatherForecastInfo.weather.description
-            temperatureLabel.text = "현재 기온 : \(infoProtocol.weatherForecastInfo.main.temp)\(infoProtocol.tempUnit.expression)"
-            feelsLikeLabel.text = "체감 기온 : \(infoProtocol.weatherForecastInfo.main.feelsLike)\(infoProtocol.tempUnit.expression)"
-            maximumTemperatureLable.text = "최고 기온 : \(infoProtocol.weatherForecastInfo.main.tempMax)\(infoProtocol.tempUnit.expression)"
-            minimumTemperatureLable.text = "최저 기온 : \(infoProtocol.weatherForecastInfo.main.tempMin)\(infoProtocol.tempUnit.expression)"
-            popLabel.text = "강수 확률 : \(infoProtocol.weatherForecastInfo.main.pop * 100)%"
-            humidityLabel.text = "습도 : \(infoProtocol.weatherForecastInfo.main.humidity)%"
-            
-            let formatter: DateFormatter = DateFormatter()
-            formatter.dateFormat = .none
-            formatter.timeStyle = .short
-            formatter.locale = .init(identifier: "ko_KR")
-            sunriseTimeLabel.text = "일출 : \(formatter.string(from: Date(timeIntervalSince1970: infoProtocol.cityInfo.sunrise)))"
-            sunsetTimeLabel.text = "일몰 : \(formatter.string(from: Date(timeIntervalSince1970: infoProtocol.cityInfo.sunset)))"
+            weatherGroupLabel.text = info.weatherForecastInfo.weather.main
+            weatherDescriptionLabel.text = info.weatherForecastInfo.weather.description
+            temperatureLabel.text = "현재 기온 : \(info.weatherForecastInfo.main.temp)\(info.tempUnit.expression)"
+            feelsLikeLabel.text = "체감 기온 : \(info.weatherForecastInfo.main.feelsLike)\(info.tempUnit.expression)"
+            maximumTemperatureLable.text = "최고 기온 : \(info.weatherForecastInfo.main.tempMax)\(info.tempUnit.expression)"
+            minimumTemperatureLable.text = "최저 기온 : \(info.weatherForecastInfo.main.tempMin)\(info.tempUnit.expression)"
+            popLabel.text = "강수 확률 : \(info.weatherForecastInfo.main.pop * 100)%"
+            humidityLabel.text = "습도 : \(info.weatherForecastInfo.main.humidity)%"
+            sunriseTimeLabel.text = "일출 : \(Date.string(from: Date(timeIntervalSince1970: info.cityInfo.sunrise), style: .short))"
+            sunsetTimeLabel.text = "일몰 : \(Date.string(from: Date(timeIntervalSince1970: info.cityInfo.sunset), style: .short))"
         }
         
         func layMainStackView() {
@@ -135,7 +130,7 @@ class DetailView: UIView {
     }
     
     func loadImage(to imageView: UIImageView) {
-        let iconName: String = infoProtocol.weatherForecastInfo.weather.icon
+        let iconName: String = info.weatherForecastInfo.weather.icon
         let urlString: String = "https://openweathermap.org/img/wn/\(iconName)@2x.png"
         
         ImageChacher.shared.load(urlString: urlString) { image in

--- a/WeatherForecast/WeatherForecast/DetailView.swift
+++ b/WeatherForecast/WeatherForecast/DetailView.swift
@@ -10,26 +10,23 @@ import UIKit
 protocol DetailViewInfoProtocol {
     var weatherForecastInfo: WeatherForecastInfo { get set }
     var cityInfo: City { get set }
-    var tempUnit: TempUnit { get set }
 }
 
 struct DetailInfo: DetailViewInfoProtocol {
     var weatherForecastInfo: WeatherForecastInfo
     var cityInfo: City
-    var tempUnit: TempUnit
     
-    init(weatherForecastInfo: WeatherForecastInfo, cityInfo: City, tempUnit: TempUnit) {
+    init(weatherForecastInfo: WeatherForecastInfo, cityInfo: City) {
         self.weatherForecastInfo = weatherForecastInfo
         self.cityInfo = cityInfo
-        self.tempUnit = tempUnit
     }
 }
 
 class DetailView: UIView {
     private let info: DetailViewInfoProtocol
     
-    init(weatherForecastInfo: WeatherForecastInfo, cityInfo: City, tempUnit: TempUnit) {
-        self.info = DetailInfo(weatherForecastInfo: weatherForecastInfo, cityInfo: cityInfo, tempUnit: tempUnit)
+    init(weatherForecastInfo: WeatherForecastInfo, cityInfo: City) {
+        self.info = DetailInfo(weatherForecastInfo: weatherForecastInfo, cityInfo: cityInfo)
         super.init(frame: .zero)
         layViews()
     }
@@ -93,10 +90,10 @@ class DetailView: UIView {
             weatherDescriptionLabel.font = .preferredFont(forTextStyle: .largeTitle)
             weatherGroupLabel.text = info.weatherForecastInfo.weather.main
             weatherDescriptionLabel.text = info.weatherForecastInfo.weather.description
-            temperatureLabel.text = "현재 기온 : \(info.weatherForecastInfo.main.temp)\(info.tempUnit.expression)"
-            feelsLikeLabel.text = "체감 기온 : \(info.weatherForecastInfo.main.feelsLike)\(info.tempUnit.expression)"
-            maximumTemperatureLable.text = "최고 기온 : \(info.weatherForecastInfo.main.tempMax)\(info.tempUnit.expression)"
-            minimumTemperatureLable.text = "최저 기온 : \(info.weatherForecastInfo.main.tempMin)\(info.tempUnit.expression)"
+            temperatureLabel.text = "현재 기온 : \(info.weatherForecastInfo.main.temp)\(Shared.tempUnit.expression)"
+            feelsLikeLabel.text = "체감 기온 : \(info.weatherForecastInfo.main.feelsLike)\(Shared.tempUnit.expression)"
+            maximumTemperatureLable.text = "최고 기온 : \(info.weatherForecastInfo.main.tempMax)\(Shared.tempUnit.expression)"
+            minimumTemperatureLable.text = "최저 기온 : \(info.weatherForecastInfo.main.tempMin)\(Shared.tempUnit.expression)"
             popLabel.text = "강수 확률 : \(info.weatherForecastInfo.main.pop * 100)%"
             humidityLabel.text = "습도 : \(info.weatherForecastInfo.main.humidity)%"
             sunriseTimeLabel.text = "일출 : \(Date.string(from: Date(timeIntervalSince1970: info.cityInfo.sunrise), style: .short))"

--- a/WeatherForecast/WeatherForecast/ImageChacher.swift
+++ b/WeatherForecast/WeatherForecast/ImageChacher.swift
@@ -1,0 +1,44 @@
+//
+//  ImageCacher.swift
+//  WeatherForecast
+//
+//  Created by 구민영 on 3/18/24.
+//
+
+import UIKit
+
+struct ImageChacher {
+    private init() {}
+    static let shared = ImageChacher()
+    
+    let imageChache: NSCache<NSString, UIImage> = NSCache()
+    
+    func chachedImage(from urlString: String) -> UIImage? {
+        return imageChache.object(forKey: urlString as NSString)
+    }
+    
+    func load(urlString: String, completion: @escaping (UIImage?) -> Void) {
+        if let cachedImage = chachedImage(from: urlString) {
+            DispatchQueue.main.async {
+                completion(cachedImage)
+            }
+            return
+        }
+        
+        Task {
+            guard let url: URL = URL(string: urlString),
+                  let (data, _) = try? await URLSession.shared.data(from: url),
+                  let image: UIImage = UIImage(data: data) else {
+                DispatchQueue.main.async {
+                    completion(nil)
+                }
+                return
+            }
+            
+            imageChache.setObject(image, forKey: urlString as NSString)
+            DispatchQueue.main.async {
+                completion(image)
+            }
+        }
+    }
+}

--- a/WeatherForecast/WeatherForecast/ViewController.swift
+++ b/WeatherForecast/WeatherForecast/ViewController.swift
@@ -137,25 +137,12 @@ extension ViewController: UITableViewDataSource {
                 
         let iconName: String = weatherForecastInfo.weather.icon         
         let urlString: String = "https://openweathermap.org/img/wn/\(iconName)@2x.png"
-                
-        if let image = imageChache.object(forKey: urlString as NSString) {
-            cell.weatherIcon.image = image
-            return cell
-        }
         
-        Task {
-            guard let url: URL = URL(string: urlString),
-                  let (data, _) = try? await URLSession.shared.data(from: url),
-                  let image: UIImage = UIImage(data: data) else {
-                return
-            }
-            
-            imageChache.setObject(image, forKey: urlString as NSString)
-            
+        ImageChacher.shared.load(urlString: urlString, completion: { image in
             if indexPath == tableView.indexPath(for: cell) {
                 cell.weatherIcon.image = image
             }
-        }
+        })
         
         return cell
     }

--- a/WeatherForecast/WeatherForecast/ViewController.swift
+++ b/WeatherForecast/WeatherForecast/ViewController.swift
@@ -165,10 +165,10 @@ extension ViewController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
         
-        let detailViewController: WeatherDetailViewController = WeatherDetailViewController()
-        detailViewController.weatherForecastInfo = weatherJSON?.weatherForecast[indexPath.row]
-        detailViewController.cityInfo = weatherJSON?.city
-        detailViewController.tempUnit = tempUnit
+        guard let weatherForecastInfo = weatherJSON?.weatherForecast[indexPath.row],
+              let cityInfo = weatherJSON?.city else {return}
+        
+        let detailViewController: WeatherDetailViewController = WeatherDetailViewController(infoProtocol: DetailInfo(weatherForecastInfo: weatherForecastInfo, cityInfo: cityInfo, tempUnit: tempUnit))
         navigationController?.show(detailViewController, sender: self)
     }
 }

--- a/WeatherForecast/WeatherForecast/ViewController.swift
+++ b/WeatherForecast/WeatherForecast/ViewController.swift
@@ -9,7 +9,11 @@ import UIKit
 class ViewController: UIViewController {
     var tableView: UITableView!
     let refreshControl: UIRefreshControl = UIRefreshControl()
-    var weatherJSON: WeatherJSON?
+    var weatherJSON: WeatherJSON? {
+        willSet {
+            setNavTitle(with: newValue?.city.name)
+        }
+    }
     var icons: [UIImage]?
     let imageChache: NSCache<NSString, UIImage> = NSCache()
     let dateFormatter: DateFormatter = {
@@ -75,6 +79,13 @@ extension ViewController {
             tableView.trailingAnchor.constraint(equalTo: safeArea.trailingAnchor)
         ])
     }
+    
+    private func setNavTitle(with text: String?) {
+        guard let text else {return}
+        DispatchQueue.main.async {
+            self.navigationItem.title = text
+        }
+    }
 }
 
 extension ViewController {
@@ -96,7 +107,6 @@ extension ViewController {
         }
 
         weatherJSON = info
-        navigationItem.title = weatherJSON?.city.name
     }
 }
 

--- a/WeatherForecast/WeatherForecast/Weather.swift
+++ b/WeatherForecast/WeatherForecast/Weather.swift
@@ -60,3 +60,6 @@ enum TempUnit: String {
     }
 }
 
+struct Shared {
+    static var tempUnit: TempUnit = .metric
+}

--- a/WeatherForecast/WeatherForecast/WeatherDetailViewController.swift
+++ b/WeatherForecast/WeatherForecast/WeatherDetailViewController.swift
@@ -19,7 +19,7 @@ class WeatherDetailViewController: UIViewController {
     }
     
     override func loadView() {
-        view = DetailView(weatherForecastInfo: info.weatherForecastInfo, cityInfo: info.cityInfo, tempUnit: info.tempUnit)
+        view = DetailView(weatherForecastInfo: info.weatherForecastInfo, cityInfo: info.cityInfo)
         layViews()
     }
     

--- a/WeatherForecast/WeatherForecast/WeatherDetailViewController.swift
+++ b/WeatherForecast/WeatherForecast/WeatherDetailViewController.swift
@@ -7,10 +7,10 @@
 import UIKit
 
 class WeatherDetailViewController: UIViewController {
-    private let infoProtocol: DetailViewInfoProtocol
+    private let info: DetailViewInfoProtocol
     
-    init(infoProtocol: DetailViewInfoProtocol) {
-        self.infoProtocol = infoProtocol
+    init(info: DetailViewInfoProtocol) {
+        self.info = info
         super.init(nibName: nil, bundle: nil)
     }
     
@@ -18,14 +18,14 @@ class WeatherDetailViewController: UIViewController {
         fatalError("init(coder:) has not been implemented")
     }
     
-    override func loadView() {view = DetailView(weatherForecastInfo: infoProtocol.weatherForecastInfo, cityInfo: infoProtocol.cityInfo, tempUnit: infoProtocol.tempUnit)
+    override func loadView() {view = DetailView(weatherForecastInfo: info.weatherForecastInfo, cityInfo: info.cityInfo, tempUnit: info.tempUnit)
         layViews()
     }
     
     private func layViews() {
         view.backgroundColor = .white
         
-        let weatherForecastInfo = infoProtocol.weatherForecastInfo
+        let weatherForecastInfo = info.weatherForecastInfo
         let date: Date = Date(timeIntervalSince1970: weatherForecastInfo.dt)
         navigationItem.title = Date.string(from: date, format: "yyyy-MM-dd(EEEEE) a HH:mm")
     }

--- a/WeatherForecast/WeatherForecast/WeatherDetailViewController.swift
+++ b/WeatherForecast/WeatherForecast/WeatherDetailViewController.swift
@@ -18,13 +18,6 @@ class WeatherDetailViewController: UIViewController {
         fatalError("init(coder:) has not been implemented")
     }
     
-    let dateFormatter: DateFormatter = {
-        let formatter: DateFormatter = DateFormatter()
-        formatter.locale = .init(identifier: "ko_KR")
-        formatter.dateFormat = "yyyy-MM-dd(EEEEE) a HH:mm"
-        return formatter
-    }()
-    
     override func loadView() {view = DetailView(weatherForecastInfo: infoProtocol.weatherForecastInfo, cityInfo: infoProtocol.cityInfo, tempUnit: infoProtocol.tempUnit)
         layViews()
     }
@@ -34,6 +27,6 @@ class WeatherDetailViewController: UIViewController {
         
         let weatherForecastInfo = infoProtocol.weatherForecastInfo
         let date: Date = Date(timeIntervalSince1970: weatherForecastInfo.dt)
-        navigationItem.title = dateFormatter.string(from: date)
+        navigationItem.title = Date.string(from: date, format: "yyyy-MM-dd(EEEEE) a HH:mm")
     }
 }

--- a/WeatherForecast/WeatherForecast/WeatherDetailViewController.swift
+++ b/WeatherForecast/WeatherForecast/WeatherDetailViewController.swift
@@ -7,7 +7,6 @@
 import UIKit
 
 class WeatherDetailViewController: UIViewController {
-
     var weatherForecastInfo: WeatherForecastInfo?
     var cityInfo: City?
     var tempUnit: TempUnit = .metric
@@ -19,109 +18,20 @@ class WeatherDetailViewController: UIViewController {
         return formatter
     }()
     
-    override func viewDidLoad() {
-        super.viewDidLoad()
-        initialSetUp()
+    override func loadView() {
+        guard let weatherForecastInfo,
+              let cityInfo else {return}
+        
+        view = DetailView(weatherForecastInfo: weatherForecastInfo, cityInfo: cityInfo, tempUnit: tempUnit)
+        layViews()
     }
     
-    private func initialSetUp() {
+    private func layViews() {
         view.backgroundColor = .white
         
-        guard let listInfo = weatherForecastInfo else { return }
+        guard let weatherForecastInfo = weatherForecastInfo else { return }
         
-        let date: Date = Date(timeIntervalSince1970: listInfo.dt)
+        let date: Date = Date(timeIntervalSince1970: weatherForecastInfo.dt)
         navigationItem.title = dateFormatter.string(from: date)
-        
-        let iconImageView: UIImageView = UIImageView()
-        let weatherGroupLabel: UILabel = UILabel()
-        let weatherDescriptionLabel: UILabel = UILabel()
-        let temperatureLabel: UILabel = UILabel()
-        let feelsLikeLabel: UILabel = UILabel()
-        let maximumTemperatureLable: UILabel = UILabel()
-        let minimumTemperatureLable: UILabel = UILabel()
-        let popLabel: UILabel = UILabel()
-        let humidityLabel: UILabel = UILabel()
-        let sunriseTimeLabel: UILabel = UILabel()
-        let sunsetTimeLabel: UILabel = UILabel()
-        let spacingView: UIView = UIView()
-        spacingView.backgroundColor = .clear
-        spacingView.setContentHuggingPriority(.defaultLow, for: .vertical)
-        
-        let mainStackView: UIStackView = .init(arrangedSubviews: [
-            iconImageView,
-            weatherGroupLabel,
-            weatherDescriptionLabel,
-            temperatureLabel,
-            feelsLikeLabel,
-            maximumTemperatureLable,
-            minimumTemperatureLable,
-            popLabel,
-            humidityLabel,
-            sunriseTimeLabel,
-            sunsetTimeLabel,
-            spacingView
-        ])
-                
-        mainStackView.arrangedSubviews.forEach { subview in
-            guard let subview: UILabel = subview as? UILabel else { return }
-            subview.textColor = .black
-            subview.backgroundColor = .clear
-            subview.numberOfLines = 1
-            subview.textAlignment = .center
-            subview.font = .preferredFont(forTextStyle: .body)
-        }
-        
-        weatherGroupLabel.font = .preferredFont(forTextStyle: .largeTitle)
-        weatherDescriptionLabel.font = .preferredFont(forTextStyle: .largeTitle)
-        
-        mainStackView.axis = .vertical
-        mainStackView.alignment = .center
-        mainStackView.spacing = 8
-        view.addSubview(mainStackView)
-        mainStackView.translatesAutoresizingMaskIntoConstraints = false
-        
-        let safeArea: UILayoutGuide = view.safeAreaLayoutGuide
-        NSLayoutConstraint.activate([
-            mainStackView.topAnchor.constraint(equalTo: safeArea.topAnchor),
-            mainStackView.bottomAnchor.constraint(equalTo: safeArea.bottomAnchor),
-            mainStackView.leadingAnchor.constraint(equalTo: safeArea.leadingAnchor,
-                                                   constant: 16),
-            mainStackView.trailingAnchor.constraint(equalTo: safeArea.trailingAnchor,
-                                                   constant: -16),
-            iconImageView.widthAnchor.constraint(equalTo: iconImageView.heightAnchor),
-            iconImageView.widthAnchor.constraint(equalTo: safeArea.widthAnchor,
-                                                 multiplier: 0.3)
-        ])
-        
-        weatherGroupLabel.text = listInfo.weather.main
-        weatherDescriptionLabel.text = listInfo.weather.description
-        temperatureLabel.text = "현재 기온 : \(listInfo.main.temp)\(tempUnit.expression)"
-        feelsLikeLabel.text = "체감 기온 : \(listInfo.main.feelsLike)\(tempUnit.expression)"
-        maximumTemperatureLable.text = "최고 기온 : \(listInfo.main.tempMax)\(tempUnit.expression)"
-        minimumTemperatureLable.text = "최저 기온 : \(listInfo.main.tempMin)\(tempUnit.expression)"
-        popLabel.text = "강수 확률 : \(listInfo.main.pop * 100)%"
-        humidityLabel.text = "습도 : \(listInfo.main.humidity)%"
-        
-        if let cityInfo {
-            let formatter: DateFormatter = DateFormatter()
-            formatter.dateFormat = .none
-            formatter.timeStyle = .short
-            formatter.locale = .init(identifier: "ko_KR")
-            sunriseTimeLabel.text = "일출 : \(formatter.string(from: Date(timeIntervalSince1970: cityInfo.sunrise)))"
-            sunsetTimeLabel.text = "일몰 : \(formatter.string(from: Date(timeIntervalSince1970: cityInfo.sunset)))"
-        }
-        
-        Task {
-            let iconName: String = listInfo.weather.icon
-            let urlString: String = "https://openweathermap.org/img/wn/\(iconName)@2x.png"
-
-            guard let url: URL = URL(string: urlString),
-                  let (data, _) = try? await URLSession.shared.data(from: url),
-                  let image: UIImage = UIImage(data: data) else {
-                return
-            }
-            
-            iconImageView.image = image
-        }
     }
 }

--- a/WeatherForecast/WeatherForecast/WeatherDetailViewController.swift
+++ b/WeatherForecast/WeatherForecast/WeatherDetailViewController.swift
@@ -7,9 +7,16 @@
 import UIKit
 
 class WeatherDetailViewController: UIViewController {
-    var weatherForecastInfo: WeatherForecastInfo?
-    var cityInfo: City?
-    var tempUnit: TempUnit = .metric
+    private let infoProtocol: DetailViewInfoProtocol
+    
+    init(infoProtocol: DetailViewInfoProtocol) {
+        self.infoProtocol = infoProtocol
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
     
     let dateFormatter: DateFormatter = {
         let formatter: DateFormatter = DateFormatter()
@@ -18,19 +25,14 @@ class WeatherDetailViewController: UIViewController {
         return formatter
     }()
     
-    override func loadView() {
-        guard let weatherForecastInfo,
-              let cityInfo else {return}
-        
-        view = DetailView(weatherForecastInfo: weatherForecastInfo, cityInfo: cityInfo, tempUnit: tempUnit)
+    override func loadView() {view = DetailView(weatherForecastInfo: infoProtocol.weatherForecastInfo, cityInfo: infoProtocol.cityInfo, tempUnit: infoProtocol.tempUnit)
         layViews()
     }
     
     private func layViews() {
         view.backgroundColor = .white
         
-        guard let weatherForecastInfo = weatherForecastInfo else { return }
-        
+        let weatherForecastInfo = infoProtocol.weatherForecastInfo
         let date: Date = Date(timeIntervalSince1970: weatherForecastInfo.dt)
         navigationItem.title = dateFormatter.string(from: date)
     }

--- a/WeatherForecast/WeatherForecast/WeatherDetailViewController.swift
+++ b/WeatherForecast/WeatherForecast/WeatherDetailViewController.swift
@@ -18,7 +18,8 @@ class WeatherDetailViewController: UIViewController {
         fatalError("init(coder:) has not been implemented")
     }
     
-    override func loadView() {view = DetailView(weatherForecastInfo: info.weatherForecastInfo, cityInfo: info.cityInfo, tempUnit: info.tempUnit)
+    override func loadView() {
+        view = DetailView(weatherForecastInfo: info.weatherForecastInfo, cityInfo: info.cityInfo, tempUnit: info.tempUnit)
         layViews()
     }
     

--- a/WeatherForecast/WeatherForecast/WeatherListDataSource.swift
+++ b/WeatherForecast/WeatherForecast/WeatherListDataSource.swift
@@ -1,0 +1,57 @@
+//
+//  WeatherListDataSource.swift
+//  WeatherForecast
+//
+//  Created by 구 민영 on 3/19/24.
+//
+
+import UIKit
+
+class WeatherListDataSource: NSObject, UITableViewDataSource {
+    var weathers: [WeatherForecastInfo]
+    var tempUnit: TempUnit
+    
+    convenience override init() {
+        self.init(weathers: [WeatherForecastInfo](), tempUnit: .metric)
+    }
+    
+    init(weathers: [WeatherForecastInfo], tempUnit: TempUnit) {
+        self.weathers = weathers
+        self.tempUnit = tempUnit
+    }
+    
+    func numberOfSections(in tableView: UITableView) -> Int {
+        1
+    }
+    
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return weathers.count
+    }
+    
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell: UITableViewCell = tableView.dequeueReusableCell(withIdentifier: "WeatherCell", for: indexPath)
+        
+        guard let cell: WeatherTableViewCell = cell as? WeatherTableViewCell else {
+            return cell
+        }
+        
+        let weatherForecastInfo = weathers[indexPath.row]
+        cell.weatherLabel.text = weatherForecastInfo.weather.main
+        cell.descriptionLabel.text = weatherForecastInfo.weather.description
+        cell.temperatureLabel.text = "\(weatherForecastInfo.main.temp)\(tempUnit.expression)"
+        
+        let date: Date = Date(timeIntervalSince1970: weatherForecastInfo.dt)
+        cell.dateLabel.text = Date.string(from: date, format: "yyyy-MM-dd(EEEEE) a HH:mm")
+                
+        let iconName: String = weatherForecastInfo.weather.icon
+        let urlString: String = "https://openweathermap.org/img/wn/\(iconName)@2x.png"
+        
+        ImageChacher.shared.load(urlString: urlString, completion: { image in
+            if indexPath == tableView.indexPath(for: cell) {
+                cell.weatherIcon.image = image
+            }
+        })
+        
+        return cell
+    }
+}

--- a/WeatherForecast/WeatherForecast/WeatherListTableDataSource.swift
+++ b/WeatherForecast/WeatherForecast/WeatherListTableDataSource.swift
@@ -9,11 +9,9 @@ import UIKit
 
 class WeatherListTableDataSource: NSObject, UITableViewDataSource {
     var weathers: [WeatherForecastInfo]
-    var tempUnit: TempUnit
     
-    init(weathers: [WeatherForecastInfo], tempUnit: TempUnit) {
+    init(weathers: [WeatherForecastInfo]) {
         self.weathers = weathers
-        self.tempUnit = tempUnit
     }
     
     func numberOfSections(in tableView: UITableView) -> Int {
@@ -34,7 +32,7 @@ class WeatherListTableDataSource: NSObject, UITableViewDataSource {
         let weatherForecastInfo = weathers[indexPath.row]
         cell.weatherLabel.text = weatherForecastInfo.weather.main
         cell.descriptionLabel.text = weatherForecastInfo.weather.description
-        cell.temperatureLabel.text = "\(weatherForecastInfo.main.temp)\(tempUnit.expression)"
+        cell.temperatureLabel.text = "\(weatherForecastInfo.main.temp)\(Shared.tempUnit.expression)"
         
         let date: Date = Date(timeIntervalSince1970: weatherForecastInfo.dt)
         cell.dateLabel.text = Date.string(from: date, format: "yyyy-MM-dd(EEEEE) a HH:mm")

--- a/WeatherForecast/WeatherForecast/WeatherListTableDataSource.swift
+++ b/WeatherForecast/WeatherForecast/WeatherListTableDataSource.swift
@@ -7,13 +7,9 @@
 
 import UIKit
 
-class WeatherListDataSource: NSObject, UITableViewDataSource {
+class WeatherListTableDataSource: NSObject, UITableViewDataSource {
     var weathers: [WeatherForecastInfo]
     var tempUnit: TempUnit
-    
-    convenience override init() {
-        self.init(weathers: [WeatherForecastInfo](), tempUnit: .metric)
-    }
     
     init(weathers: [WeatherForecastInfo], tempUnit: TempUnit) {
         self.weathers = weathers

--- a/WeatherForecast/WeatherForecast/WeatherListTableDelegate.swift
+++ b/WeatherForecast/WeatherForecast/WeatherListTableDelegate.swift
@@ -1,0 +1,31 @@
+//
+//  WeatherListTableDelegate.swift
+//  WeatherForecast
+//
+//  Created by 구 민영 on 3/19/24.
+//
+
+import UIKit
+
+class WeatherListTableDelegate: NSObject, UITableViewDelegate {
+    let baseVC: UIViewController
+    var weathers: [WeatherForecastInfo]
+    var city: City
+    var tempUnit: TempUnit
+    
+    init(baseVC: UIViewController, weathers: [WeatherForecastInfo], city: City, tempUnit: TempUnit) {
+        self.baseVC = baseVC
+        self.weathers = weathers
+        self.city = city
+        self.tempUnit = tempUnit
+    }
+    
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        tableView.deselectRow(at: indexPath, animated: true)
+        
+        let weatherForecastInfo = weathers[indexPath.row]
+        
+        let detailViewController: WeatherDetailViewController = WeatherDetailViewController(info: DetailInfo(weatherForecastInfo: weatherForecastInfo, cityInfo: city, tempUnit: tempUnit))
+        baseVC.navigationController?.show(detailViewController, sender: self)
+    }
+}

--- a/WeatherForecast/WeatherForecast/WeatherListTableDelegate.swift
+++ b/WeatherForecast/WeatherForecast/WeatherListTableDelegate.swift
@@ -11,13 +11,11 @@ class WeatherListTableDelegate: NSObject, UITableViewDelegate {
     let baseVC: UIViewController
     var weathers: [WeatherForecastInfo]
     var city: City
-    var tempUnit: TempUnit
     
-    init(baseVC: UIViewController, weathers: [WeatherForecastInfo], city: City, tempUnit: TempUnit) {
+    init(baseVC: UIViewController, weathers: [WeatherForecastInfo], city: City) {
         self.baseVC = baseVC
         self.weathers = weathers
         self.city = city
-        self.tempUnit = tempUnit
     }
     
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
@@ -25,7 +23,7 @@ class WeatherListTableDelegate: NSObject, UITableViewDelegate {
         
         let weatherForecastInfo = weathers[indexPath.row]
         
-        let detailViewController: WeatherDetailViewController = WeatherDetailViewController(info: DetailInfo(weatherForecastInfo: weatherForecastInfo, cityInfo: city, tempUnit: tempUnit))
+        let detailViewController: WeatherDetailViewController = WeatherDetailViewController(info: DetailInfo(weatherForecastInfo: weatherForecastInfo, cityInfo: city))
         baseVC.navigationController?.show(detailViewController, sender: self)
     }
 }

--- a/WeatherForecast/WeatherForecast/WeatherListViewController.swift
+++ b/WeatherForecast/WeatherForecast/WeatherListViewController.swift
@@ -8,9 +8,11 @@ import UIKit
 
 class WeatherListViewController: UIViewController {
     var tableView: UITableView!
+    let refreshControl: UIRefreshControl = UIRefreshControl()
+    
     var weatherListDataSource: WeatherListTableDataSource?
     var weatherListDelegate: WeatherListTableDelegate?
-    let refreshControl: UIRefreshControl = UIRefreshControl()
+    
     var weatherJSON: WeatherJSON? {
         willSet {
             setNavTitle(with: newValue?.city.name)
@@ -18,8 +20,6 @@ class WeatherListViewController: UIViewController {
             setTableDelegate(with: newValue)
         }
     }
-    var icons: [UIImage]?
-    let imageChache: NSCache<NSString, UIImage> = NSCache()
     var tempUnit: TempUnit = .metric
     
     override func viewDidLoad() {
@@ -118,17 +118,3 @@ extension WeatherListViewController {
         weatherJSON = info
     }
 }
-
-extension WeatherListViewController: UITableViewDelegate {
-    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        tableView.deselectRow(at: indexPath, animated: true)
-        
-        guard let weatherForecastInfo = weatherJSON?.weatherForecast[indexPath.row],
-              let cityInfo = weatherJSON?.city else {return}
-        
-        let detailViewController: WeatherDetailViewController = WeatherDetailViewController(info: DetailInfo(weatherForecastInfo: weatherForecastInfo, cityInfo: cityInfo, tempUnit: tempUnit))
-        navigationController?.show(detailViewController, sender: self)
-    }
-}
-
-

--- a/WeatherForecast/WeatherForecast/WeatherListViewController.swift
+++ b/WeatherForecast/WeatherForecast/WeatherListViewController.swift
@@ -32,7 +32,6 @@ class WeatherListViewController: UIViewController {
             setTableDataSourceAndDelegate(with: newValue)
         }
     }
-    var tempUnit: TempUnit = .metric
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -42,12 +41,12 @@ class WeatherListViewController: UIViewController {
 
 extension WeatherListViewController {
     @objc private func changeTempUnit() {
-        switch tempUnit {
+        switch Shared.tempUnit {
         case .imperial:
-            tempUnit = .metric
+            Shared.tempUnit = .metric
             navigationItem.rightBarButtonItem?.title = "섭씨"
         case .metric:
-            tempUnit = .imperial
+            Shared.tempUnit = .imperial
             navigationItem.rightBarButtonItem?.title = "화씨"
         }
         refresh()
@@ -100,8 +99,8 @@ extension WeatherListViewController {
         guard let weathers = jsonData?.weatherForecast,
               let city = jsonData?.city else {return}
         
-        let weatherListDataSource = WeatherListTableDataSource(weathers: weathers, tempUnit: tempUnit)
-        let weatherListDelegate = WeatherListTableDelegate(baseVC: self, weathers: weathers, city: city, tempUnit: tempUnit)
+        let weatherListDataSource = WeatherListTableDataSource(weathers: weathers)
+        let weatherListDelegate = WeatherListTableDelegate(baseVC: self, weathers: weathers, city: city)
         
         tableViewAdopter = WeatherListTableViewAdopter(weatherListDataSource: weatherListDataSource, weatherListDelegate: weatherListDelegate)
         tableView.dataSource = weatherListDataSource

--- a/WeatherForecast/WeatherForecast/WeatherListViewController.swift
+++ b/WeatherForecast/WeatherForecast/WeatherListViewController.swift
@@ -6,7 +6,7 @@
 
 import UIKit
 
-class ViewController: UIViewController {
+class WeatherListViewController: UIViewController {
     var tableView: UITableView!
     let refreshControl: UIRefreshControl = UIRefreshControl()
     var weatherJSON: WeatherJSON? {
@@ -16,13 +16,6 @@ class ViewController: UIViewController {
     }
     var icons: [UIImage]?
     let imageChache: NSCache<NSString, UIImage> = NSCache()
-    let dateFormatter: DateFormatter = {
-        let formatter: DateFormatter = DateFormatter()
-        formatter.locale = .init(identifier: "ko_KR")
-        formatter.dateFormat = "yyyy-MM-dd(EEEEE) a HH:mm"
-        return formatter
-    }()
-    
     var tempUnit: TempUnit = .metric
     
     override func viewDidLoad() {
@@ -31,7 +24,7 @@ class ViewController: UIViewController {
     }
 }
 
-extension ViewController {
+extension WeatherListViewController {
     @objc private func changeTempUnit() {
         switch tempUnit {
         case .imperial:
@@ -88,7 +81,7 @@ extension ViewController {
     }
 }
 
-extension ViewController {
+extension WeatherListViewController {
     private func fetchWeatherJSON() {
         
         let jsonDecoder: JSONDecoder = .init()
@@ -110,7 +103,7 @@ extension ViewController {
     }
 }
 
-extension ViewController: UITableViewDataSource {
+extension WeatherListViewController: UITableViewDataSource {
     
     func numberOfSections(in tableView: UITableView) -> Int {
         1
@@ -133,7 +126,7 @@ extension ViewController: UITableViewDataSource {
         cell.temperatureLabel.text = "\(weatherForecastInfo.main.temp)\(tempUnit.expression)"
         
         let date: Date = Date(timeIntervalSince1970: weatherForecastInfo.dt)
-        cell.dateLabel.text = dateFormatter.string(from: date)
+        cell.dateLabel.text = Date.string(from: date, format: "yyyy-MM-dd(EEEEE) a HH:mm")
                 
         let iconName: String = weatherForecastInfo.weather.icon         
         let urlString: String = "https://openweathermap.org/img/wn/\(iconName)@2x.png"
@@ -148,7 +141,7 @@ extension ViewController: UITableViewDataSource {
     }
 }
 
-extension ViewController: UITableViewDelegate {
+extension WeatherListViewController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
         

--- a/WeatherForecast/WeatherForecast/WeatherTableViewCell.swift
+++ b/WeatherForecast/WeatherForecast/WeatherTableViewCell.swift
@@ -12,9 +12,11 @@ class WeatherTableViewCell: UITableViewCell {
     var temperatureLabel: UILabel!
     var weatherLabel: UILabel!
     var descriptionLabel: UILabel!
+    var dashLabel: UILabel!
      
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
+        initialSetUp()
         layViews()
         reset()
     }
@@ -28,14 +30,16 @@ class WeatherTableViewCell: UITableViewCell {
         reset()
     }
     
-    private func layViews() {
+    private func initialSetUp() {
         weatherIcon = UIImageView()
         dateLabel = UILabel()
         temperatureLabel = UILabel()
         weatherLabel = UILabel()
-        let dashLabel: UILabel = UILabel()
         descriptionLabel = UILabel()
-        
+        dashLabel = UILabel()
+    }
+    
+    private func layLabels() {
         let labels: [UILabel] = [dateLabel, temperatureLabel, weatherLabel, dashLabel, descriptionLabel]
         
         labels.forEach { label in
@@ -44,20 +48,27 @@ class WeatherTableViewCell: UITableViewCell {
             label.numberOfLines = 1
         }
         
-        let weatherStackView: UIStackView = UIStackView(arrangedSubviews: [
+        descriptionLabel.setContentHuggingPriority(.defaultLow,
+                                                   for: .horizontal)
+    }
+    
+    private func weatherStackView() -> UIStackView {
+        let weatherStackView = UIStackView(arrangedSubviews: [
             weatherLabel,
             dashLabel,
             descriptionLabel
         ])
-        
-        descriptionLabel.setContentHuggingPriority(.defaultLow,
-                                                   for: .horizontal)
         
         weatherStackView.axis = .horizontal
         weatherStackView.spacing = 8
         weatherStackView.alignment = .center
         weatherStackView.distribution = .fill
         
+        return weatherStackView
+    }
+    
+    private func verticalStackView() -> UIStackView {
+        let weatherStackView = weatherStackView()
         
         let verticalStackView: UIStackView = UIStackView(arrangedSubviews: [
             dateLabel,
@@ -70,19 +81,30 @@ class WeatherTableViewCell: UITableViewCell {
         verticalStackView.distribution = .fill
         verticalStackView.alignment = .leading
         
+        return verticalStackView
+    }
+    
+    private func contentsStackView() -> UIStackView {
+        let verticalStackView = verticalStackView()
+        
         let contentsStackView: UIStackView = UIStackView(arrangedSubviews: [
             weatherIcon,
             verticalStackView
         ])
-               
+        
         contentsStackView.axis = .horizontal
         contentsStackView.spacing = 16
         contentsStackView.alignment = .center
         contentsStackView.distribution = .fill
         contentsStackView.translatesAutoresizingMaskIntoConstraints = false
-        
+               
+        return contentsStackView
+    }
+    
+    private func layContentsStackView() {
+        let contentsStackView = contentsStackView()
         contentView.addSubview(contentsStackView)
-                
+
         NSLayoutConstraint.activate([
             contentsStackView.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 16),
             contentsStackView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 16),
@@ -93,11 +115,24 @@ class WeatherTableViewCell: UITableViewCell {
         ])
     }
     
-    private func reset() {
-        weatherIcon.image = UIImage(systemName: "arrow.down.circle.dotted")
-        dateLabel.text = "0000-00-00 00:00:00"
-        temperatureLabel.text = "00℃"
-        weatherLabel.text = "~~~"
-        descriptionLabel.text = "~~~~~"
+    private func layViews() {
+        layLabels()
+        layContentsStackView()
     }
+    
+    private func reset() {
+        weatherIcon.image = UIImage(systemName: Placeholder.weatherIcon)
+        dateLabel.text = Placeholder.dateLabel
+        temperatureLabel.text = Placeholder.temperatureLabel
+        weatherLabel.text = Placeholder.weatherLabel
+        descriptionLabel.text = Placeholder.descriptionLabel
+    }
+}
+
+enum Placeholder {
+    static let weatherIcon = "arrow.down.circle.dotted"
+    static let dateLabel = "0000-00-00 00:00:00"
+    static let temperatureLabel = "00℃"
+    static let weatherLabel = "~~~"
+    static let descriptionLabel = "~~~~~"
 }


### PR DESCRIPTION
@ryan-son 
안녕하세요! 1주차 코드리뷰 감사드리며, 2주차 PR 보냅니다.

## 고민했던 점
### SRP, ISP, DIP
- WeatherTableViewCell의 layViews에서 모든 UI 컴포넌트 초기화 및 레이아웃을 설정하고 있기 때문에 이를 컴포넌트별로 분리했습니다.
- fetchWeatherJSON 메서드가 fetch 기능만 수행하도록 네비게이션 타이틀을 설정하는 메서드를 별도로 구현해 분리했습니다.
- 화면을 그리는 역할은 View에서 수행하도록 DetailView를 생성해 WeatherDetailViewController에서 책임을 덜어냈습니다.
- 상세정보를 추상화해 WeatherDetailViewController, DetailView와의 의존성을 분리했습니다.
- 중복 코드를 제거하기 위해 싱글톤 패턴과 extension을 사용해서 이미지캐싱, DateFormatter 생성을 처리했습니다.
- 중복 코드를 제거하기 위해 타입프로퍼티로 tempUnit(화씨/섭씨) 값을 관리합니다. 처음에는 싱글톤을 떠올렸으나 값을 읽고 쓰는 단순한 작업만 필요하기 때문에 Shared 클래스에 타입프로퍼티만 두었습니다.
- UITableViewDataSource/Delegate를 각각 추상화해 ISP와 DIP를 실현해보았습니다.
### 기타
- ImageChacher의 load 함수에서 UIImage를 리턴할까 하였으나, 호출한 곳에서 UIImage를 받아 결국에는 UI 업데이트 작업을 수행할테니 메인스레드로 감싸 클로저를 사용하는 completion 형태로 작업했습니다.

 ---

## 해결이 되지 않은 점
### 의존성 주입 시점
- WeatherListViewController와 TableView DataSource/Delegate의 의존성을 분리했습니다. json 데이터가 세팅되면 WeatherListViewController의 setTableDataSourceAndDelegate 메서드에서 인스턴스를 생성해 의존성을 주입합니다. 그런데 1주차 코드리뷰에 의하면 이 방식은 유연성이 떨어지는 것 같아요. (이니셜라이저 내부 또는 메서드 내부에서 필요한 인스턴스를 생성하는 방식은 인스턴스로 변경해 사용할 수 없으므로 유연성이 떨어진다고 말씀 주셨습니다.) 이를 개선하기 위해서는 setTableDataSourceAndDelegate 매개변수로 WeatherListTableViewAdopter를 받아서 처리해면 되는 걸까요?
### 구체 타입 추상화
- WeatherListViewController에서 WeatherJSON 구체 타입의 프로퍼티를 가지고 있습니다. 다른 타입의 데이터가 들어와도 코드를 적게 수정하려면 이것도 추상화하면 좋을 것 같은데, 맞을까요?

---

## 조언을 얻고 싶은 부분
### VC에서 TableViewDataSource/Delegate를 분리했을 때의 이점
- ViewController에서 책임을 덜어냈으니 SRP 관점에서는 개선되었다고 생각합니다. 코드도 간결해졌구요. 그런데 DIP 관점에서는 잘 모르겠습니다. 특정 DataSource/Delegate에 구속 되지 않아서 좋은 걸까요? 현재 코드 기준으로는 WeatherListTableDataSource, WeatherListTableDataSource 내부에 있는 구체 타입([WeatherForecastInfo], City)까지 추상화해야 의존성이 완전리 분리될 것 같은데 제가 제대로 이해 했는지 궁금합니다. 이외의 장점도 함께 알려주시면 감사하겠습니다.
### willSet /  didSet 사용에 대한 고찰
- 이번 예제에서처럼, 현업에서도 특정 프로퍼티의 값이 변경된 후 수행하고 싶은 작업이 있을 때 willSet/didSet을 빈번하게 사용하고 있습니다. 프로젝트가 커질수록 그 내부에서 처리하는 코드도 많아지는데요. willSet/didSet에서 이렇게 온갖 작업을 다 해도 성능 이슈는 없는지, 다른 개선 방안이 있는지 질문 드립니다.
### 중첩함수와 SRP
- DetailView 클래스의 layViews메서드 한 곳에서 모든 UI 컴포넌트 초기화 및 레이아웃을 설정하고 싶지 않았습니다. 그런데 컴포넌트를 메서드 내부에서 선언했기 때문에 메서드 분리가 어려워 중첩함수로 사용했습니다. 이것도 SRP로 볼 수 있을까요?
### UI컴포넌트 선언
- 저는 UI컴포넌트를 클래스의 멤버변수로 두는 방식을 늘 사용해왔는데, 예제에서는 이렇게 하지 않고 메서드 내에서 선언해 사용하는 코드를 자주 접했습니다. 생각해보니 멤버변수로 둔다는 건 접근제어자를 무엇으로 지정했냐에 따라 여러 곳에서 접근할 수도 있다는 의미이고, 의존성 측면에서 코드 품질 저하가 일어날 우려가 있겠구나 싶었습니다. 뷰 내부에서 레이아웃 잡을 때만 쓴다면 예제처럼 메서드에서 선언하는 방식이 더 좋겠다는 생각이 들었습니다. 다만 생소한 방식이라.. 다른 분들도 이렇게 많이들 사용하는지,  사용한다면 제가 이해한 의도로 쓰는 게 맞는지, 또다른 이점이 있는지 궁금합니다.
